### PR TITLE
Added bubbleTintColor property

### DIFF
--- a/Demo/LIVBubbleMenu/Base.lproj/Main.storyboard
+++ b/Demo/LIVBubbleMenu/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14D87h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
     </dependencies>
     <scenes>
         <!--LIVBubbleMenu-->
@@ -27,8 +27,8 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WUy-tb-32T">
-                                <rect key="frame" x="250" y="90" width="100" height="30"/>
-                                <state key="normal" title="Partial Menu">
+                                <rect key="frame" x="181" y="90" width="239" height="30"/>
+                                <state key="normal" title="Partial Menu with custom tint color">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>

--- a/Demo/LIVBubbleMenu/ViewController.m
+++ b/Demo/LIVBubbleMenu/ViewController.m
@@ -55,6 +55,7 @@
     _bubbleMenu.easyButtons = NO;
     _bubbleMenu.bubbleStartAngle = 0.0f;
     _bubbleMenu.bubbleTotalAngle = 180.0f;
+    _bubbleMenu.bubbleTintColor = [UIColor greenColor];
     [_bubbleMenu show];
 }
 

--- a/LIVBubbleMenu/LIVBubbleMenu.h
+++ b/LIVBubbleMenu/LIVBubbleMenu.h
@@ -35,6 +35,7 @@
 @property (nonatomic, assign) float bubblePopOutDuration; // The amount of seconds it takes for a bubble to reach its hide position  (default is 1.0f)
 @property (nonatomic, assign) float bubbleStartAngle; // Initial angle to start bubbles (default is 0.0f)
 @property (nonatomic, assign) float bubbleTotalAngle; // Total available degrees in the bubble menu (default is 360)
+@property (nonatomic, assign) UIColor *bubbleTintColor; // Tint color for bubble images
 @property (nonatomic, assign) BOOL easyButtons; // simple or complex button styling (set NO if buttons have alpha channel) (default is YES);
 
 // Background

--- a/LIVBubbleMenu/LIVBubbleMenu.m
+++ b/LIVBubbleMenu/LIVBubbleMenu.m
@@ -314,6 +314,10 @@
     button.frame = CGRectMake(0, 0, 2 * _bubbleRadius, 2 * _bubbleRadius);
 
     if (_easyButtons) {
+        if (_bubbleTintColor) {
+            image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+            [button setTintColor:_bubbleTintColor];
+        }
         [button setImage:image forState:UIControlStateNormal];
     } else {
         // Circle background
@@ -326,6 +330,10 @@
 
         // Circle icon
         UIImageView *icon = [[UIImageView alloc] initWithImage:image];
+        if (_bubbleTintColor) {
+            [icon setTintColor:_bubbleTintColor];
+            icon.image = [icon.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        }
         CGRect f = icon.frame;
         f.origin.x = (CGFloat) ((circle.frame.size.width - f.size.width) * 0.5);
         f.origin.y = (CGFloat) ((circle.frame.size.height - f.size.height) * 0.5);


### PR DESCRIPTION
Enables users to set custom tint colors for images in bubbles.
Works with both easyButton = YES, and NO.
I updated the example to show how it works, but feel free to remove it if it shouldn't be there.
